### PR TITLE
Eliminación de comentarios "eslint-disable" para los archivos del proyecto 1.

### DIFF
--- a/src/messaging/edit.js
+++ b/src/messaging/edit.js
@@ -34,16 +34,10 @@ const __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, 
 };
 
 /* Seccion: IMPORTACIONES */
-/* eslint-disable @typescript-eslint/no-var-requires */
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const meta = require('../meta');
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const user = require('../user');
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const plugins = require('../plugins');
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const privileges = require('../privileges');
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const sockets = require('../socket.io');
 
 /* Seccion: FUNCIONES */
@@ -55,8 +49,6 @@ module.exports = function (Messaging) {
 
 		if (raw === content) return;
 
-		// eslint-disable-next-line max-len
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
 		const payload = yield plugins.hooks.fire('filter:messaging.edit', { content: content, edited: Date.now() });
 		if (!String(payload.content).trim()) throw new Error('[[error:invalid-chat-message]]');
 
@@ -65,14 +57,10 @@ module.exports = function (Messaging) {
 		// Propagate this change to users in the room
 		const messages = yield Messaging.getMessagesData([mid], uid, roomId, true);
 		if (messages[0]) {
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 			const roomName = messages[0].deleted ? `uid_${uid}` : `chat_room_${roomId}`;
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 			sockets.in(roomName).emit('event:chats.edit', { messages: messages });
 		}
 
-		// eslint-disable-next-line max-len
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
 		yield plugins.hooks.fire('action:messaging.edit', { message: { ...messages[0], content: payload.content } });
 	});
 
@@ -87,39 +75,27 @@ module.exports = function (Messaging) {
 		const exists = yield Messaging.messageExists(messageId);
 		if (!exists) throw new Error('[[error:invalid-mid]]');
 
-		// eslint-disable-next-line max-len
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
 		const isAdminOrGlobalMod = yield user.isAdminOrGlobalMod(uid);
 
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 		if (meta.config.disableChat) {
 			throw new Error('[[error:chat-disabled]]');
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 		} else if (!isAdminOrGlobalMod && meta.config.disableChatMessageEditing) {
 			throw new Error('[[error:chat-message-editing-disabled]]');
 		}
 
-		// eslint-disable-next-line max-len
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
 		const userData = yield user.getUserFields(uid, ['banned']);
 
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 		if (userData.banned) throw new Error('[[error:user-banned]]');
 
-		// eslint-disable-next-line max-len
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
 		const canChat = yield privileges.global.can(['chat', 'chat:privileged'], uid);
 
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 		if (!canChat.includes(true)) throw new Error('[[error:no-privileges]]');
 
 		const messageData = yield Messaging.getMessageFields(messageId, ['fromuid', 'timestamp', 'system']);
 		if (isAdminOrGlobalMod && !messageData.system) return;
 
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
 		const chatConfigDuration = meta.config[durationConfig];
 		if (chatConfigDuration && Date.now() - messageData.timestamp > chatConfigDuration * 1000) {
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 			throw new Error(`[[error:chat-${type}-duration-expired, ${chatConfigDuration}]]`);
 		}
 
@@ -131,9 +107,7 @@ module.exports = function (Messaging) {
 	Messaging.canEdit = (messageId, uid) => __awaiter(this, undefined, undefined, function* () { return yield canEditDelete(messageId, uid, 'edit'); });
 	Messaging.canDelete = (messageId, uid) => __awaiter(this, undefined, undefined, function* () { return yield canEditDelete(messageId, uid, 'delete'); });
 	Messaging.canPin = (roomId, uid) => __awaiter(this, undefined, undefined, function* () {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 		const [isAdmin, isGlobalMod, inRoom, isRoomOwner] = yield Promise.all([
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 			user.isAdministrator(uid), user.isGlobalModerator(uid),
 			Messaging.isUserInRoom(uid, roomId), Messaging.isRoomOwner(uid, roomId),
 		]);

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -11,21 +11,14 @@ const intFields = [
 ];
 function modifyPost(post, fields) {
 	if (post) {
-		// La siguiente línea llama a una función en un módulo que aún no ha sido actualizado a TS
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 		(0, database_1.parseIntFields)(post, intFields, fields);
 		if (post.hasOwnProperty('upvotes') && post.hasOwnProperty('downvotes')) {
 			post.votes = post.upvotes - post.downvotes;
 		}
 		if (post.hasOwnProperty('timestamp')) {
-			// La siguiente línea llama a una función en un módulo que aún no ha sido actualizado a TS
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
 			post.timestampISO = (0, utils_1.toISOString)(post.timestamp);
 		}
 		if (post.hasOwnProperty('edited')) {
-			// La siguiente línea llama a una función en un módulo que aún no ha sido actualizado a TS
-			// eslint-disable-next-line max-len
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
 			post.editedISO = post.edited !== 0 ? (0, utils_1.toISOString)(post.edited) : '';
 		}
 	}
@@ -36,12 +29,7 @@ function toExport(Posts) {
 			return [];
 		}
 		const keys = pids.map(pid => `post:${pid}`);
-		// La siguiente línea llama a una función en un módulo que aún no ha sido actualizado a TS
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
 		const postData = await (0, database_1.getObjects)(keys, fields);
-		// La siguiente línea llama a una función en un módulo que aún no ha sido actualizado a TS
-		// eslint-disable-next-line max-len
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
 		const result = await plugins_1.hooks.fire('filter:post.getFields', {
 			pids: pids,
 			posts: postData,
@@ -75,11 +63,7 @@ function toExport(Posts) {
 		await Posts.setPostFields(pid, { [field]: value });
 	};
 	Posts.setPostFields = async function (pid, data) {
-		// La siguiente línea llama a una función en un módulo que aún no ha sido actualizado a TS
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 		await (0, database_1.setObject)(`post:${pid}`, data);
-		// La siguiente línea llama a una función en un módulo que aún no ha sido actualizado a TS
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 		await plugins_1.hooks.fire('action:post.setFields', { data: { ...data, pid } });
 	};
 }


### PR DESCRIPTION
# Limpieza de Archivos

No es seguro tener comentarios de eslint'

Para tener una mejor versión de los archivos proporcionados por el Proyecto 1 y asegurar el correcto funcionamiento del ESLint se eliminarón las lineas "eslint-disable" respectivas. Los arcchivos tocados en este PR son
    * `src/messaging/edit.js`
    * `src/posts/data.js`