### PR TITLE
HU1 y HU2 (Back-End) - Inclusión y modificación de Rol para profesores/teacher, validación de creación de materias.

### DIFF
--- a/src/cli/user.js
+++ b/src/cli/user.js
@@ -49,6 +49,10 @@ module.exports = () => {
 		.description('Make user(s) an admin')
 		.arguments('<uids...>')
 		.action((...args) => execute(userCommands.makeAdmin, args));
+	make.command('teacher')
+		.description('Make user(s) a Teachers')
+		.arguments('<uids...>')
+		.action((...args) => execute(userCommands.makeTeacher, args));
 	make.command('global-mod')
 		.description('Make user(s) a global moderator')
 		.arguments('<uids...>')
@@ -268,6 +272,13 @@ ${pwGenerated ? ` Generated password: ${password}` : ''}`);
 		await Promise.all(uids.map(uid => groups.join('administrators', uid)));
 
 		winston.info('[userCmd/make/admin] User(s) added as administrators.');
+	}
+
+	async function makeTeacher(uids) {
+		uids = argParsers.intArrayParse(uids, 'uids');
+		await Promise.all(uids.map(uid => groups.join('Teachers', uid)));
+
+		winston.info('[userCmd/make/globalMod] User(s) added as global moderators.');
 	}
 
 	async function makeGlobalMod(uids) {

--- a/src/cli/user.js
+++ b/src/cli/user.js
@@ -278,7 +278,7 @@ ${pwGenerated ? ` Generated password: ${password}` : ''}`);
 		uids = argParsers.intArrayParse(uids, 'uids');
 		await Promise.all(uids.map(uid => groups.join('Teachers', uid)));
 
-		winston.info('[userCmd/make/globalMod] User(s) added as global moderators.');
+		winston.info('[userCmd/make/teacher] User(s) added as teachers.');
 	}
 
 	async function makeGlobalMod(uids) {
@@ -301,7 +301,7 @@ ${pwGenerated ? ` Generated password: ${password}` : ''}`);
 	async function makeRegular(uids) {
 		uids = argParsers.intArrayParse(uids, 'uids');
 
-		await Promise.all(uids.map(uid => groups.leave(['administrators', 'Global Moderators'], uid)));
+		await Promise.all(uids.map(uid => groups.leave(['administrators', 'Global Moderators', "Teachers"], uid)));
 
 		const categoryPrivList = await privileges.categories.getPrivilegeList();
 		const cids = await db.getSortedSetRevRange('categories:cid', 0, -1);
@@ -316,6 +316,7 @@ ${pwGenerated ? ` Generated password: ${password}` : ''}`);
 		reset,
 		deleteUser,
 		makeAdmin,
+		makeTeacher,
 		makeGlobalMod,
 		makeMod,
 		makeRegular,

--- a/src/cli/user.js
+++ b/src/cli/user.js
@@ -301,7 +301,7 @@ ${pwGenerated ? ` Generated password: ${password}` : ''}`);
 	async function makeRegular(uids) {
 		uids = argParsers.intArrayParse(uids, 'uids');
 
-		await Promise.all(uids.map(uid => groups.leave(['administrators', 'Global Moderators', "Teachers"], uid)));
+		await Promise.all(uids.map(uid => groups.leave(['administrators', 'Global Moderators', 'Teachers'], uid)));
 
 		const categoryPrivList = await privileges.categories.getPrivilegeList();
 		const cids = await db.getSortedSetRevRange('categories:cid', 0, -1);

--- a/src/groups/create.js
+++ b/src/groups/create.js
@@ -10,7 +10,8 @@ module.exports = function (Groups) {
 		const isSystem = isSystemGroup(data);
 		const timestamp = data.timestamp || Date.now();
 		let disableJoinRequests = parseInt(data.disableJoinRequests, 10) === 1 ? 1 : 0;
-		if (data.name === 'administrators') {
+		// Inclusion de creacion para profesores.
+		if (data.name === 'administrators' || data.name === 'teachers') {
 			disableJoinRequests = 1;
 		}
 		const disableLeave = parseInt(data.disableLeave, 10) === 1 ? 1 : 0;

--- a/src/groups/index.js
+++ b/src/groups/index.js
@@ -34,6 +34,7 @@ Groups.systemGroups = [
 	Groups.BANNED_USERS,
 	'administrators',
 	'Global Moderators',
+	'Teachers',
 ];
 
 Groups.getEphemeralGroup = function (groupName) {

--- a/src/privileges/global.js
+++ b/src/privileges/global.js
@@ -114,7 +114,7 @@ privsGlobal.can = async function (privilege, uid) {
 		helpers.isAllowedTo(isArray ? privilege : [privilege], uid, 0),
 	]);
 	return isArray ?
-		isUserAllowedTo.map(allowed => isAdministrator || allowed) :
+		isUserAllowedTo.map(allowed => isAdministrator || isTeacher || allowed) :
 		isAdministrator || isTeacher || isUserAllowedTo[0];
 };
 

--- a/src/privileges/global.js
+++ b/src/privileges/global.js
@@ -24,6 +24,7 @@ const _privilegeMap = new Map([
 	['signature', { label: '[[admin/manage/privileges:signature]]', type: 'posting' }],
 	['invite', { label: '[[admin/manage/privileges:invite]]', type: 'posting' }],
 	['group:create', { label: '[[admin/manage/privileges:allow-group-creation]]', type: 'posting' }],
+	['group:create', { label: '[[teachers/manage/privileges:allow-group-creation]]', type: 'posting' }],
 	['search:content', { label: '[[admin/manage/privileges:search-content]]', type: 'viewing' }],
 	['search:users', { label: '[[admin/manage/privileges:search-users]]', type: 'viewing' }],
 	['search:tags', { label: '[[admin/manage/privileges:search-tags]]', type: 'viewing' }],
@@ -107,13 +108,14 @@ privsGlobal.get = async function (uid) {
 
 privsGlobal.can = async function (privilege, uid) {
 	const isArray = Array.isArray(privilege);
-	const [isAdministrator, isUserAllowedTo] = await Promise.all([
+	const [isAdministrator, isTeacher, isUserAllowedTo] = await Promise.all([
 		user.isAdministrator(uid),
+		user.isTeacher(uid),
 		helpers.isAllowedTo(isArray ? privilege : [privilege], uid, 0),
 	]);
 	return isArray ?
 		isUserAllowedTo.map(allowed => isAdministrator || allowed) :
-		isAdministrator || isUserAllowedTo[0];
+		isAdministrator || isTeacher || isUserAllowedTo[0];
 };
 
 privsGlobal.canGroup = async function (privilege, groupName) {

--- a/src/privileges/helpers.js
+++ b/src/privileges/helpers.js
@@ -139,6 +139,7 @@ helpers.getGroupPrivileges = async function (cid, groupPrivileges) {
 	groupNames = groups.ephemeralGroups.concat(groupNames);
 	moveToFront(groupNames, groups.BANNED_USERS);
 	moveToFront(groupNames, 'Global Moderators');
+	moveToFront(groupNames, 'Teachers');
 	moveToFront(groupNames, 'unverified-users');
 	moveToFront(groupNames, 'verified-users');
 	moveToFront(groupNames, 'registered-users');

--- a/src/privileges/teacher.js
+++ b/src/privileges/teacher.js
@@ -1,0 +1,225 @@
+
+'use strict';
+
+const _ = require('lodash');
+
+const user = require('../user');
+const groups = require('../groups');
+const helpers = require('./helpers');
+const plugins = require('../plugins');
+const utils = require('../utils');
+
+const privsTeacher = module.exports;
+
+/**
+ * Looking to add a new teacher privilege via plugin/theme? Attach a hook to
+ * `static:privileges.teacher.init` and call .set() on the privilege map passed
+ * in to your listener.
+ */
+const _privilegeTeacherMap = new Map([
+	['teacher:dashboard', { label: '[[teacher/manage/privileges:teacher-dashboard]]', type: 'teacher' }],
+	['teacher:categories', { label: '[[teacher/manage/privileges:teacher-categories]]', type: 'teacher' }],
+	['teacher:privileges', { label: '[[teacher/manage/privileges:teacher-privileges]]', type: 'teacher' }],
+	// ['teacher:teachers-mods', { label: '[[teacher/manage/privileges:teacher-teachers-mods]]', type: 'teacher' }],
+	['teacher:users', { label: '[[teacher/manage/privileges:teacher-users]]', type: 'teacher' }],
+	['teacher:groups', { label: '[[teacher/manage/privileges:teacher-groups]]', type: 'teacher' }],
+	['teacher:tags', { label: '[[teacher/manage/privileges:teacher-tags]]', type: 'teacher' }],
+	['teacher:settings', { label: '[[teacher/manage/privileges:teacher-settings]]', type: 'teacher' }],
+]);
+
+privsTeacher.init = async () => {
+	await plugins.hooks.fire('static:privileges.teacher.init', {
+		privileges: _privilegeTeacherMap,
+	});
+
+	for (const [, value] of _privilegeTeacherMap) {
+		if (value && !value.type) {
+			value.type = 'other';
+		}
+	}
+};
+
+privsTeacher.getUserPrivilegeList = async () => await plugins.hooks.fire('filter:privileges.teacher.list', Array.from(_privilegeTeacherMap.keys()));
+privsTeacher.getGroupPrivilegeList = async () => await plugins.hooks.fire('filter:privileges.teacher.groups.list', Array.from(_privilegeTeacherMap.keys()).map(privilege => `groups:${privilege}`));
+privsTeacher.getPrivilegeList = async () => {
+	const [user, group] = await Promise.all([
+		privsTeacher.getUserPrivilegeList(),
+		privsTeacher.getGroupPrivilegeList(),
+	]);
+	return user.concat(group);
+};
+
+// Mapping for a page route (via direct match or regexp) to a privilege
+privsTeacher.routeMap = {
+	dashboard: 'teacher:dashboard',
+	'manage/categories': 'teacher:categories',
+	'manage/privileges': 'teacher:privileges',
+	// 'manage/teachers-mods': 'teacher:teachers-mods',
+	'manage/users': 'teacher:users',
+	'manage/groups': 'teacher:groups',
+	'manage/tags': 'teacher:tags',
+	'settings/tags': 'teacher:tags',
+	'extend/plugins': 'teacher:settings',
+	'extend/widgets': 'teacher:settings',
+	'extend/rewards': 'teacher:settings',
+	// uploads
+	'category/uploadpicture': 'teacher:categories',
+	uploadfavicon: 'teacher:settings',
+	uploadTouchIcon: 'teacher:settings',
+	uploadMaskableIcon: 'teacher:settings',
+	uploadlogo: 'teacher:settings',
+	uploadOgImage: 'teacher:settings',
+	uploadDefaultAvatar: 'teacher:settings',
+};
+privsTeacher.routePrefixMap = {
+	'dashboard/': 'teacher:dashboard',
+	'manage/categories/': 'teacher:categories',
+	'manage/privileges/': 'teacher:privileges',
+	'manage/groups/': 'teacher:groups',
+	'settings/': 'teacher:settings',
+	'appearance/': 'teacher:settings',
+	'plugins/': 'teacher:settings',
+};
+
+// Mapping for socket call methods to a privilege
+// In NodeBB v2, these socket calls will be removed in favour of xhr calls
+privsTeacher.socketMap = {
+	'teacher.rooms.getAll': 'teacher:dashboard',
+	'teacher.analytics.get': 'teacher:dashboard',
+
+	'teacher.categories.copySettingsFrom': 'teacher:categories',
+	'teacher.categories.copyPrivilegesToChildren': 'teacher:privileges',
+	'teacher.categories.copyPrivilegesFrom': 'teacher:privileges',
+	'teacher.categories.copyPrivilegesToAllCategories': 'teacher:privileges',
+
+	// 'teacher.user.maketeachers': 'teacher:teachers-mods',
+	// 'teacher.user.removeteachers': 'teacher:teachers-mods',
+
+	'teacher.user.loadGroups': 'teacher:users',
+	'teacher.groups.join': 'teacher:users',
+	'teacher.groups.leave': 'teacher:users',
+	'teacher.user.resetLockouts': 'teacher:users',
+	'teacher.user.validateEmail': 'teacher:users',
+	'teacher.user.sendValidationEmail': 'teacher:users',
+	'teacher.user.sendPasswordResetEmail': 'teacher:users',
+	'teacher.user.forcePasswordReset': 'teacher:users',
+	'teacher.user.invite': 'teacher:users',
+
+	'teacher.tags.create': 'teacher:tags',
+	'teacher.tags.rename': 'teacher:tags',
+	'teacher.tags.deleteTags': 'teacher:tags',
+
+	'teacher.getSearchDict': 'teacher:settings',
+	'teacher.config.setMultiple': 'teacher:settings',
+	'teacher.config.remove': 'teacher:settings',
+	'teacher.themes.getInstalled': 'teacher:settings',
+	'teacher.themes.set': 'teacher:settings',
+	'teacher.reloadAllSessions': 'teacher:settings',
+	'teacher.settings.get': 'teacher:settings',
+	'teacher.settings.set': 'teacher:settings',
+};
+
+privsTeacher.resolve = (path) => {
+	if (privsTeacher.routeMap.hasOwnProperty(path)) {
+		return privsTeacher.routeMap[path];
+	}
+
+	const found = Object.entries(privsTeacher.routePrefixMap)
+		.filter(entry => path.startsWith(entry[0]))
+		.sort((entry1, entry2) => entry2[0].length - entry1[0].length);
+	if (!found.length) {
+		return undefined;
+	}
+	return found[0][1]; // [0] is path [1] is privilege
+};
+
+privsTeacher.list = async function (uid) {
+	const privilegeLabels = Array.from(_privilegeTeacherMap.values()).map(data => data.label);
+	const userPrivilegeList = await privsTeacher.getUserPrivilegeList();
+	const groupPrivilegeList = await privsTeacher.getGroupPrivilegeList();
+
+	// Restrict privileges column to superteachers
+	if (!(await user.isTeacher(uid))) {
+		const idx = Array.from(_privilegeTeacherMap.keys()).indexOf('teacher:privileges');
+		privilegeLabels.splice(idx, 1);
+		userPrivilegeList.splice(idx, 1);
+		groupPrivilegeList.splice(idx, 1);
+	}
+
+	const labels = await utils.promiseParallel({
+		users: plugins.hooks.fire('filter:privileges.teacher.list_human', privilegeLabels.slice()),
+		groups: plugins.hooks.fire('filter:privileges.teacher.groups.list_human', privilegeLabels.slice()),
+	});
+
+	const keys = {
+		users: userPrivilegeList,
+		groups: groupPrivilegeList,
+	};
+
+	const payload = await utils.promiseParallel({
+		labels,
+		labelData: Array.from(_privilegeTeacherMap.values()),
+		users: helpers.getUserPrivileges(0, keys.users),
+		groups: helpers.getGroupPrivileges(0, keys.groups),
+	});
+	payload.keys = keys;
+
+	return payload;
+};
+
+privsTeacher.get = async function (uid) {
+	const userPrivilegeList = await privsTeacher.getUserPrivilegeList();
+	const [userPrivileges, isteacheristrator] = await Promise.all([
+		helpers.isAllowedTo(userPrivilegeList, uid, 0),
+		user.isteacheristrator(uid),
+	]);
+
+	const combined = userPrivileges.map(allowed => allowed || isteacheristrator);
+	const privData = _.zipObject(userPrivilegeList, combined);
+
+	privData.superteacher = isteacheristrator;
+	return await plugins.hooks.fire('filter:privileges.teacher.get', privData);
+};
+
+privsTeacher.can = async function (privilege, uid) {
+	const [isUserAllowedTo, isteacheristrator] = await Promise.all([
+		helpers.isAllowedTo(privilege, uid, [0]),
+		user.isTeacher(uid),
+	]);
+	return isteacheristrator || isUserAllowedTo[0];
+};
+
+privsTeacher.canGroup = async function (privilege, groupName) {
+	return await groups.isMember(groupName, `cid:0:privileges:groups:${privilege}`);
+};
+
+privsTeacher.give = async function (privileges, groupName) {
+	await helpers.giveOrRescind(groups.join, privileges, 0, groupName);
+	plugins.hooks.fire('action:privileges.teacher.give', {
+		privileges: privileges,
+		groupNames: Array.isArray(groupName) ? groupName : [groupName],
+	});
+};
+
+privsTeacher.rescind = async function (privileges, groupName) {
+	await helpers.giveOrRescind(groups.leave, privileges, 0, groupName);
+	plugins.hooks.fire('action:privileges.teacher.rescind', {
+		privileges: privileges,
+		groupNames: Array.isArray(groupName) ? groupName : [groupName],
+	});
+};
+
+privsTeacher.userPrivileges = async function (uid) {
+	const userPrivilegeList = await privsTeacher.getUserPrivilegeList();
+	return await helpers.userOrGroupPrivileges(0, uid, userPrivilegeList);
+};
+
+privsTeacher.groupPrivileges = async function (groupName) {
+	const groupPrivilegeList = await privsTeacher.getGroupPrivilegeList();
+	return await helpers.userOrGroupPrivileges(0, groupName, groupPrivilegeList);
+};
+
+privsTeacher.getUidsWithPrivilege = async function (privilege) {
+	const uidsByCid = await helpers.getUidsWithPrivilege([0], privilege);
+	return uidsByCid[0];
+};

--- a/src/privileges/users.js
+++ b/src/privileges/users.js
@@ -17,7 +17,7 @@ privsUsers.isAdministrator = async function (uid) {
 
 // Inclusion de validacion de privilegios de profesor.
 privsUsers.isTeacher = async function (uid) {
-	return await isGroupMember(uid, 'teachers');
+	return await isGroupMember(uid, 'Teachers');
 };
 
 privsUsers.isGlobalModerator = async function (uid) {
@@ -83,15 +83,17 @@ privsUsers.canEdit = async function (callerUid, uid) {
 		return true;
 	}
 
-	const [isAdmin, isGlobalMod, isTargetAdmin, isUserAllowedTo] = await Promise.all([
+	const [isAdmin, isGlobalMod, isTargetAdmin, isUserAllowedTo, isTeacher] = await Promise.all([
 		privsUsers.isAdministrator(callerUid),
 		privsUsers.isGlobalModerator(callerUid),
 		privsUsers.isAdministrator(uid),
 		helpers.isAllowedTo('admin:users', callerUid, [0]),
+		privsUsers.isTeacher(uid),
 	]);
 	const canManageUsers = isUserAllowedTo[0];
 	const data = await plugins.hooks.fire('filter:user.canEdit', {
 		isAdmin: isAdmin,
+		isTeacher: isTeacher,
 		isGlobalMod: isGlobalMod,
 		isTargetAdmin: isTargetAdmin,
 		canManageUsers: canManageUsers,

--- a/src/privileges/users.js
+++ b/src/privileges/users.js
@@ -15,6 +15,11 @@ privsUsers.isAdministrator = async function (uid) {
 	return await isGroupMember(uid, 'administrators');
 };
 
+// Inclusion de validacion de privilegios de profesor.
+privsUsers.isTeacher = async function (uid) {
+	return await isGroupMember(uid, 'teachers');
+};
+
 privsUsers.isGlobalModerator = async function (uid) {
 	return await isGroupMember(uid, 'Global Moderators');
 };

--- a/src/upgrades/1.0.0/teachers.js
+++ b/src/upgrades/1.0.0/teachers.js
@@ -1,0 +1,22 @@
+'use strict';
+
+module.exports = {
+	name: 'Creating Teachers group',
+	timestamp: Date.UTC(2024, 0, 27),
+	method: async function () {
+		const groups = require('../../groups');
+		const exists = await groups.exists('Teachers');
+		if (exists) {
+			return;
+		}
+		await groups.create({
+			name: 'Teachers',
+			userTitle: 'Teachers',
+			description: 'List of Professors',
+			hidden: 0,
+			private: 1,
+			disableJoinRequests: 1,
+		});
+		await groups.show('Teachers');
+	},
+};

--- a/src/user/create.js
+++ b/src/user/create.js
@@ -27,7 +27,6 @@ module.exports = function (User) {
 		}
 
 		try {
-			console.log(data)
 			return await create(data);
 		} finally {
 			await db.deleteObjectFields('locks', [data.username, data.email]);

--- a/src/user/create.js
+++ b/src/user/create.js
@@ -27,6 +27,7 @@ module.exports = function (User) {
 		}
 
 		try {
+			console.log(data)
 			return await create(data);
 		} finally {
 			await db.deleteObjectFields('locks', [data.username, data.email]);
@@ -97,7 +98,8 @@ module.exports = function (User) {
 			db.incrObjectField('global', 'userCount'),
 			analytics.increment('registrations'),
 			db.sortedSetAddBulk(bulkAdd),
-			groups.join(['registered-users', 'unverified-users'], userData.uid),
+			// Creacion de estudiantes o profesores
+			data.isProfessor ? groups.join(['registered-users', 'unverified-users', 'Teachers'], userData.uid) : groups.join(['registered-users', 'unverified-users'], userData.uid),
 			User.notifications.sendWelcomeNotification(userData.uid),
 			storePassword(userData.uid, data.password),
 			User.updateDigestSetting(userData.uid, meta.config.dailyDigestFreq),

--- a/src/user/index.js
+++ b/src/user/index.js
@@ -157,6 +157,11 @@ User.isAdministrator = async function (uid) {
 	return await privileges.users.isAdministrator(uid);
 };
 
+// Inclusion de funcion validacion de profesor.
+User.isTeacher = async function (uid) {
+	return await privileges.users.isTeacher(uid);
+};
+
 User.isGlobalModerator = async function (uid) {
 	return await privileges.users.isGlobalModerator(uid);
 };


### PR DESCRIPTION
# Razonamiento
Dado que NodeBB contiene funcionalidades variadas para la creación de "Grupos", la logística que presenta NodeBB para el dominio de los roles dentro de la aplicación depende totalmente de los grupos. Por tanto, si eres administrador es porque perteneces al grupo "Administrators". Sin embargo, dichos grupos no son comunes, dado que pertenecen al ```SISTEMA```, no puede ser borrados. En este sentido, se busca la creación de un nuevo grupo de sistema TEACHERS con los permisos de creacion de  grupos(son grupos comunes que actuan como materias).

# Modificaciones y Creaciones
* Se modificaron los archivos
    *  `src/cli/user.js`: Inclusión de la funcionalidad makeTeacher como tambien la modificación de funcionalidad de hacer usuarios regulares.
    * `src/groups/index.js`: Inclusión de un nuevo tag llamado Teachers al systemGroups para el funcionamiento de los profesores en el sistema grupos.
    * `src/groups/create.js`: Inclusión de verificación al crear grupos para profesores/teachers.
    * `src/privileges/global.js`:  Modificacion en privilegios global para funcionalidad "can" y asi los usuarios Teachers obtengan la posibilidad de crear materias/cursos.
    * `src/privileges/helpers.js`: A nivel de helpers se incluyó en groupsNames a Teacher como parte de las etiquetas en el dashboard de administrador.
    * `src/privileges/users.js`: Por parte de users se incluyó la funcionalidad de verificar si un usuario es Teacher mediante la funcionalidad de isGroupMember de Teacher y la misma idea para las funcionalidades de edición.
    * `src/user/index.js`: Inclusión de funcion isTeacher para validación de usuarios profesores/teacher.
    * `src/user/create.js`: Manipulación de group.join para usuarios que tengan atributo booleado "isProfessor", se incluyen a grupo Teacher si son profesores, de lo contrario serán estudiantes.

* Se crearon los archivos:
   * `src/previleges/teacher.js`: Creación de archivo teacher.js con los permisos y funcionalidades acordes a un profesor/teacher.
   * `src/upgrade/1.0.0/teachers.js`: Creacion de archivo para el grupo/rol profesores/teachers que permite la inicialización por defecto del grupo de profesores en la aplicación.

Issue asociado: #15 y #17

# Pruebas

> [!WARNING]
> Para las pruebas mediante POSTMAN se tuvo que desactivar temporalmente el sistema token-csrf en el archivo `src/middleware/index.js` solo dejando la funcion `next()` evitando la validacion del token. 
> ![image](https://github.com/user-attachments/assets/104d962b-9486-4b4f-ab7c-944c12adb958)

### Caso para Profesores:
* Mediante el uso de Postman para la URL `http://localhost:4567/register` bajo el JSON
```JSON 
{
  "username": "JMLTUnderCode",
  "password": "admin1234!",
  "password-confirm": "admin1234!",
  "token": "",
  "noscript": "false",
  "_csrf": "aed32d4bc65845a355c940d06989217e4d5572d845caea4e36474873e030db628301741d9fbcdb970e8c586f049b8eb44a39a2498ad4f9c37708034fcd1c5bcd",
  "userLang": "en-US",
  "register": true,
  "gdpr_consent": true,
  "email": "jmltundercode@gmail.com",
  "isProfessor": true
}
```
Donde se observa que tenemos el nuevo atributo `Boolean` de usuario `isProfessor`. DIcho valor en este ejemplo indica que el usuario se esta registrando como PROFESOR en el sistema. Entonces, se obtiene un RESPONSE  con el `userID` como se muestra en la imagen a continuación
![image](https://github.com/user-attachments/assets/49a5bece-6525-4939-a8da-ee375e331ac5)

* Se valida la creación del usuario desde la perspectiva de otro usuario.
![image](https://github.com/user-attachments/assets/f0f11699-21d4-48f8-b1bc-bef39293ec3a)

* A si mismo, se valida la creación del usuario como TEACHER
![image](https://github.com/user-attachments/assets/8c9612ec-f08f-412b-a969-b3106373d264)

* Desde la perspectiva de un Administrador se tiene que el usuario creado posee el tag de Teachers, validando la pertenencia del mismo al grupo de profesores.
![image](https://github.com/user-attachments/assets/988073ab-8b35-4094-a674-26b08c73d424)

* El grupo Teacher, que a su vez, representa un rol dentro de la aplicación es creado por defecto como un grupo del sistema. 
![image](https://github.com/user-attachments/assets/664811ab-f360-4e95-a03f-8b6ebdf69504)
![image](https://github.com/user-attachments/assets/680f8cb7-8e3c-437b-aea0-5afdc39a412e)

* Desde la perspectiva del usuario CREADO: JMLTUnderCode tenemos la pertenencia y los permisos requeridos para crear nuevos "Grupos" que realmente serán MATERIAS/CURSOS (Esto se modifica en historias de usuarios posteriores)
![image](https://github.com/user-attachments/assets/5b54fcb3-66f5-40a7-92b2-863cdf4688dc)

* Se valida la creación de una nueva materia desde la perspectiva del profesor JMLTUnderCode.
![image](https://github.com/user-attachments/assets/030424b4-c123-4b41-b879-ff40f5ac208b)
![image](https://github.com/user-attachments/assets/f6d3a362-4841-43bb-94bb-9f1dce3600e7)

* Ahora se valida la creación de la materia desde la perspectiva de un Administrador. Notando que la materia creada es un "grupo" que no es del sistema por tanto no representa un concepto de Rol en la aplicación.
![image](https://github.com/user-attachments/assets/8bfacbce-53ef-4a6f-add4-c2d9b9a0e215)

* Se verifica la propiedad de la materia creada desde la perspectiva de un Administrador
![image](https://github.com/user-attachments/assets/a877b8fd-412a-4940-b882-41c2bdf5ac7b)

### Caso para Estudiantes(Usuarios normales):
* Realizamos la creación de un nuevo usuario pero el atributo isProfessor es false, por tanto se esta registrando como estudiante.
![image](https://github.com/user-attachments/assets/40172107-f7a9-4d09-87f0-6d81504c8eeb)

* Se verifica que dicho usuario no tiene los privilegios y que no pertenece al grupo de profesores/Teachers.
![image](https://github.com/user-attachments/assets/46464fc0-c3cb-48a6-a9b7-9f5108ae5d79)

* Desde la perspectiva de un Administrador se valida que el usuario solo es un usuario normal.
![image](https://github.com/user-attachments/assets/342d3ed4-7945-419d-962d-2459f16f3f50)

fixed #15 
fixed #17 