### PR TITLE
Implementación de permisos de acceso a grupos comunes 

### DIFF
--- a/src/privileges/users.js
+++ b/src/privileges/users.js
@@ -154,6 +154,38 @@ privsUsers.hasBanPrivilege = async uid => await hasGlobalPrivilege('ban', uid);
 privsUsers.hasMutePrivilege = async uid => await hasGlobalPrivilege('mute', uid);
 privsUsers.hasInvitePrivilege = async uid => await hasGlobalPrivilege('invite', uid);
 
+privsUsers.hasGroupPerms = async function (uid, groups) {
+
+	const [isAdmin, isGlobalMod, isTeacher] = await Promise.all([
+		user.isAdministrator(uid),
+		user.isGlobalModerator(uid),
+		user.isTeacher(uid),
+	]);
+
+	let list = true
+
+	if (!Array.isArray(groups)) {
+		list = false
+		groups = [groups]
+	} else {
+		groups = groups.map(group => group.name)
+	}
+
+	const groupsFiltered = groups.map(groupName =>  
+		isAdmin || 
+		(
+			!(groupName == "administrators") && (
+				isGlobalMod || (
+					!(groupName == "Global Moderators") && 
+					(isTeacher || !(groupName == "Teachers")) 
+				)
+			)
+		)
+	)
+
+	return (list) ? groupsFiltered : groupsFiltered[0]
+}
+
 async function hasGlobalPrivilege(privilege, uid) {
 	const privsGlobal = require('./global');
 	const privilegeName = privilege.split('-').map(word => word.slice(0, 1).toUpperCase() + word.slice(1)).join('');


### PR DESCRIPTION
Se implementó un sistema de permiso de acceso a grupos comunes en base a roles. Hay 3 grupos comunes para Administradores, Moderadores globales, y Profesores. Hay 4 roles de usuario, los 3 ya mencionados y los Estudiantes. Se creó una validación para determinar si un rol tiene permiso de acceso a los grupos comunes. Se estableció una jerarquía para roles de la siguiente manera

1. Administradores
2. Moderadores globales
3. Profesores
4. Estudiantes

Cada rol puede ver solo los grupos comunes de roles iguales o mayores. Esto significa que los administradores pueden ver todos los grupos comunes, y los estudiantes no pueden ver ninguno