### PR TITLE
Inclusión de funcionalidad de creación de categoría cuando se crea una matería

### DIFF
--- a/src/api/categories.js
+++ b/src/api/categories.js
@@ -11,7 +11,7 @@ const privileges = require('../privileges');
 const categoriesAPI = module.exports;
 
 const hasAdminPrivilege = async (uid, privilege = 'categories') => {
-	const ok = await privileges.admin.can(`admin:${privilege}`, uid);
+	const ok = await privileges.admin.can(`admin:${privilege}`, uid) || user.isTeacher(uid);
 	if (!ok) {
 		throw new Error('[[error:no-privileges]]');
 	}
@@ -47,7 +47,7 @@ categoriesAPI.get = async function (caller, data) {
 
 categoriesAPI.create = async function (caller, data) {
 	await hasAdminPrivilege(caller.uid);
-
+	
 	const response = await categories.create(data);
 	const categoryObjs = await categories.getCategories([response.cid]);
 	return categoryObjs[0];

--- a/src/api/categories.js
+++ b/src/api/categories.js
@@ -47,7 +47,7 @@ categoriesAPI.get = async function (caller, data) {
 
 categoriesAPI.create = async function (caller, data) {
 	await hasAdminPrivilege(caller.uid);
-	
+
 	const response = await categories.create(data);
 	const categoryObjs = await categories.getCategories([response.cid]);
 	return categoryObjs[0];

--- a/src/api/groups.js
+++ b/src/api/groups.js
@@ -9,6 +9,7 @@ const user = require('../user');
 const meta = require('../meta');
 const notifications = require('../notifications');
 const slugify = require('../slugify');
+const categories = require('../categories');
 
 const groupsAPI = module.exports;
 
@@ -37,6 +38,26 @@ groupsAPI.create = async function (caller, data) {
 	data.ownerUid = caller.uid;
 	data.system = false;
 	const groupData = await groups.create(data);
+
+	// Creación de categoria respectiva al grupo
+	let dataCategory = {
+		name: groupData.name,
+		parentCid: null,
+		order: null,
+		description: "Join our dynamic Q&A forum for \'" + groupData.name.split(" | ")[1] + "\' where university professors and students collaborate, explore, and share knowledge. Dive into meaningful discussions, solve complex challenges, and enrich your learning experience together!",
+		descriptionParsed: "Join our dynamic Q&A forum for \'" + groupData.name.split(" | ")[1] + "\' where university professors and students collaborate, explore, and share knowledge. Dive into meaningful discussions, solve complex challenges, and enrich your learning experience together!",
+		icon: null,
+		bgColor: null,
+		color: null,
+		disabled: 0,
+		link: null,
+		class: null,
+		backgroundImage: null,
+		cloneFromCid: null,
+		cloneChildren: null,
+	}
+	await categories.create(dataCategory);
+
 	logGroupEvent(caller, 'group-create', {
 		groupName: data.name,
 	});

--- a/src/api/groups.js
+++ b/src/api/groups.js
@@ -40,12 +40,12 @@ groupsAPI.create = async function (caller, data) {
 	const groupData = await groups.create(data);
 
 	// Creación de categoria respectiva al grupo
-	let dataCategory = {
+	const dataCategory = {
 		name: groupData.name,
 		parentCid: null,
 		order: null,
-		description: "Join our dynamic Q&A forum for \'" + groupData.name.split(" | ")[1] + "\' where university professors and students collaborate, explore, and share knowledge. Dive into meaningful discussions, solve complex challenges, and enrich your learning experience together!",
-		descriptionParsed: "Join our dynamic Q&A forum for \'" + groupData.name.split(" | ")[1] + "\' where university professors and students collaborate, explore, and share knowledge. Dive into meaningful discussions, solve complex challenges, and enrich your learning experience together!",
+		description: `Join our dynamic Q&A forum for '${groupData.name.split(' | ')[1]}' where university professors and students collaborate, explore, and share knowledge. Dive into meaningful discussions, solve complex challenges, and enrich your learning experience together!`,
+		descriptionParsed: `Join our dynamic Q&A forum for '${groupData.name.split(' | ')[1]}' where university professors and students collaborate, explore, and share knowledge. Dive into meaningful discussions, solve complex challenges, and enrich your learning experience together!`,
 		icon: null,
 		bgColor: null,
 		color: null,
@@ -55,7 +55,7 @@ groupsAPI.create = async function (caller, data) {
 		backgroundImage: null,
 		cloneFromCid: null,
 		cloneChildren: null,
-	}
+	};
 	await categories.create(dataCategory);
 
 	logGroupEvent(caller, 'group-create', {


### PR DESCRIPTION
# Razonamiento
Dado que las solicitudes de Front a Back se realizan bajo la API, se busca entonces modificar la función creada dentro de la API relacionada a Groups y para las categorías se busca la funcionalidad neta de creación de categorías. En la sección de Categories se tuvo que manipular los privilegios de creación de categorías en la aplicación dado que esta funcionalidad sólo esta habilitada para administradores del sistema. En la parte de grupos se realizo la llamada interna a creación de categoría con su respectiva información.

resolves #52

# Modificaciones
* Se modificaron los archivos:
    * ```src/api/categories.js```: Modificación de validación de permisos al crear nuevas categorias. Esta funcionalidad estaba solo permitida para Administradores, sin embargo se modificó para que también los profesores puedan crear una categoria al crear la materia.
    * ```src/api/groups.js```:  Inclusión de llamada a la función create de categorías al momento de crear un grupo. Se genera el data estructurado con la información del grupo para su posterior creación a nivel de categoría.

# Pruebas
Al momento de crear un curso se muestra en la sección de cursos respectivamente
![image](https://github.com/user-attachments/assets/1c96ae6f-536f-4c60-9ebd-88e9f69fdf7a)

Así mismo, observamos la creación de categorías
![image](https://github.com/user-attachments/assets/5ce3dae6-faef-4766-b2a8-8ac00be546c9)

