### PR TITLE
Cambia el nombre y la descripción de las categorías predeterminadas

### DIFF
--- a/install/data/categories.json
+++ b/install/data/categories.json
@@ -1,35 +1,35 @@
 [
     {
-        "name": "Announcements",
-        "description": "Announcements regarding our community",
-        "descriptionParsed": "<p>Announcements regarding our community</p>\n",
+        "name": "Anuncios",
+        "description": "Anuncios sobre nuestra comunidad universitaria",
+        "descriptionParsed": "<p>Anuncios sobre nuestra comunidad</p>\n",
         "bgColor": "#fda34b",
         "color": "#ffffff",
         "icon" : "fa-bullhorn",
         "order": 1
     },
     {
-        "name": "General Discussion",
-        "description": "A place to talk about whatever you want",
-        "descriptionParsed": "<p>A place to talk about whatever you want</p>\n",
+        "name": "Discuciones Generales",
+        "description": "Un lugar para hablar de lo que quieras relacionado con la universidad",
+        "descriptionParsed": "<p>Un lugar para hablar de lo que quieras</p>\n",
         "bgColor": "#59b3d0",
         "color": "#ffffff",
         "icon" : "fa-comments-o",
         "order": 2
     },
     {
-        "name": "Blogs",
-        "description": "Blog posts from individual members",
-        "descriptionParsed": "<p>Blog posts from individual members</p>\n",
+        "name": "Noticias",
+        "description": "Noticias de interés sobre nuestra universidad",
+        "descriptionParsed": "<p>Noticias de interés sobre nuestra universidad</p>\n",
         "bgColor": "#86ba4b",
         "color": "#ffffff",
         "icon" : "fa-newspaper-o",
         "order": 4
     },
     {
-        "name": "Comments & Feedback",
-        "description": "Got a question? Ask away!",
-        "descriptionParsed": "<p>Got a question? Ask away!</p>\n",
+        "name": "Denuncias y Quejas",
+        "description": "¿Algo no te parece correcto? ¡Denúncialo!",
+        "descriptionParsed": "<p>¿Algo no te parece correcto? ¡Denúncialo!</p>\n",
         "bgColor": "#e95c5a",
         "color": "#ffffff",
         "icon" : "fa-question",


### PR DESCRIPTION
En este pull request se cambia el nombre y la descripción asociada a las categorías a instalarse por default en la página de NodeBB. 

**Es necesario volver a hacer ./nodebb setup para que estos cambios se apliquen.** 

# Modificaciones

* install/data/categories.json: En este archivo se encuentra un arreglo que contiene las cuatro categorías que deberían crearse inicialmente con `./nodebb setup`. Para estas cuatro categorías se cambió sus nombres y descripciones para que estuvieran más relacionadas con temas universitarios: 
  * Categoría Announcements -> Pasó a ser la categoría Anuncios y se tradujo al español su descripción
  * Categoría General  Discussion -> Pasó a ser la categoría Discusión General y se tradujo al español su descripción
  * Categoría Blogs -> Pasó a ser la categoría Noticias y su descripción pasó a ser "Noticias de interés sobre nuestra universidad"
  * Categoría Comments & Feedback -> Pasó a ser la categoría Denuncias y Quejas y su descripción pasó a ser "¿Algo no te parece correcto? ¡Denúncialo!"

Issues asociados: closes #57 

# Razonamiento

A pesar de que se pretendía, en un principio, evitar la creación de estas categorías, con la excepción de Announcements, esto traía consigo problemas con la manera en que estan configurados los tests. Estos tests dependen de la creación de cuatro categorías iniciales. Por lo que, se decidió mantener estas categorías y darles un enfoque distinto a sus funcionalidades. 

# Pruebas

Para probar la creación exitosa de las categorías, clonamos el repositorio nuevamente y hacemos `./nodebb setup`. Al hacer `./nodebb start` vemos que las categorías con sus nuevos nombres y descripciones.

![image](https://github.com/user-attachments/assets/f8420550-890b-4fe4-85ee-623bdae4d06f)
 